### PR TITLE
Make cleanfiles.pl check the database

### DIFF
--- a/BuildFarmWeb.pl.skel
+++ b/BuildFarmWeb.pl.skel
@@ -19,6 +19,7 @@ use vars qw(
   $all_stat $fail_stat $change_stat $green_stat
   $captcha_invis_pubkey $captcha_invis_privkey
   $template_dir
+  $buildlogs_dir
   $default_host
   $local_git_clone
   $status_from $register_from $reminders_from $alerts_from
@@ -48,6 +49,7 @@ $status_url = 'https://buildfarm.postgresql.org';
 my $base_install_dir = '/path/to/install/website';
 
 $template_dir = "$base_install_dir/templates";
+$buildlogs_dir = "$base_install_dir/buildlogs";
 
 $default_host = 'foohost.pgbuildfarm.org';
 

--- a/bin/cleanfiles.pl
+++ b/bin/cleanfiles.pl
@@ -5,7 +5,14 @@ eval 'exec /usr/bin/perl -S $0 ${1+"$@"}'
 use strict;
 use warnings;
 
+use DBI;
+use DBD::Pg;
+
+use File::Spec;
 use File::Find ();
+
+use vars qw($dbhost $dbname $dbuser $dbpass $dbport
+  $default_host $buildlogs_dir);
 
 # Set the variable $File::Find::dont_use_nlink if you're using AFS,
 # since AFS cheats.
@@ -16,12 +23,29 @@ use vars qw/*name *dir *prune/;
 *dir   = *File::Find::dir;
 *prune = *File::Find::prune;
 
+require "$ENV{BFConfDir}/BuildFarmWeb.pl";
+
+die "no dbname" unless $dbname;
+die "no dbuser" unless $dbuser;
+
+my $dsn = "dbi:Pg:dbname=$dbname";
+$dsn .= ";host=$dbhost" if $dbhost;
+$dsn .= ";port=$dbport" if $dbport;
+
+my $db = DBI->connect($dsn, $dbuser, $dbpass);
+
+die $DBI::errstr unless $db;
+
+my $sth = $db->prepare("SELECT sysname FROM build_status WHERE sysname = ? and snapshot = ?", { pg_server_prepare => 1 });
+
 sub wanted;
 
 my @files;
 
 # Traverse desired filesystems
-File::Find::find({ wanted => \&wanted }, '/home/pgbuildfarm/website/buildlogs');
+File::Find::find({ wanted => \&wanted }, $buildlogs_dir);
+
+$sth->finish();
 
 foreach my $fname (@files)
 {
@@ -29,20 +53,88 @@ foreach my $fname (@files)
 	unlink($fname) || warn "$fname: $!";
 }
 
+$db->disconnect;
+
 exit;
 
 ## no critic (ValuesAndExpressions::ProhibitFiletest_f)
 
 sub wanted
 {
-	my ($dev, $ino, $mode, $nlink, $uid, $gid);
+	my ($dev, $ino, $mode, $nlink, $uid, $gid, $rv);
 
-	(($dev, $ino, $mode, $nlink, $uid, $gid) = lstat($_))
-	  && (int(-M _) > 7)
-	  &&
+	# Get the base filename into $file.
+	my ($volume,$directories,$file) = File::Spec->splitpath( $_ );
 
-	  #    ( -M _ > 0.05 ) && # 1.2 hours
-	  -f _
-	  && push(@files, $name);
+	# ignore hidden files and directories
+	if ($file =~ /^\./)
+	{
+		return;
+	}
+
+	# TODO: change these files to be named better so we can check them too
+	# instead of just nuking them when they get to be old..
+	if ($file =~ /^tmp\.\d+\.(tgz|unpacklogs)$/)
+	{
+		(($dev, $ino, $mode, $nlink, $uid, $gid) = lstat($_))
+		  && (int(-M _) > 7)
+		  &&
+
+		  #    ( -M _ > 0.05 ) && # 1.2 hours
+		  -f _
+		  && push (@files, $name);
+
+		return;
+	}
+
+	# File names we are interested in are animal.DATETIME, so split them
+	# up to use in the query.
+	my ($animal, $ts) = split(/\./, $file);
+
+	if (!defined($animal) || !defined($ts) || $animal eq '' || $ts eq '')
+	{
+		warn "unrecognized file found: `$file', ignoring";
+		return;
+	}
+
+	$sth->bind_param(1, $animal);
+	$sth->bind_param(2, $ts);
+
+	# Check if the run has been imported yet or not.
+	$rv = $sth->execute();
+	if (!defined($rv))
+	{
+		warn "error querying database for `$file': $sth->errstr";
+		return;
+	}
+
+	# We should only get one, or no, rows returned.
+	if ($rv != 1 && $rv != 0)
+	{
+		warn "checking $file: wrong number of rows returned!";
+		return;
+	}
+
+	if ($rv == 1)
+	{
+		# We got a row back, so this import should be done,
+		# but just double-check that it's the same animal.
+		die "got different animal" unless $animal eq $sth->fetch()->[0];
+
+		push (@files, $name);
+	}
+	else
+	{
+		# complain if the file has gotten to be old enough that
+		# it really *should* have been imported by now
+		(($dev, $ino, $mode, $nlink, $uid, $gid) = lstat($_))
+		  && (int(-M _) > 7)
+		  &&
+
+		  #    ( -M _ > 0.05 ) && # 1.2 hours
+		  -f _
+		  && warn "$name hasn't been imported yet!";
+	}
+
 	return;
 }

--- a/cgi-bin/pgstatus.pl
+++ b/cgi-bin/pgstatus.pl
@@ -485,13 +485,12 @@ if ($sqlres)
 
 	$sth->finish;
 
-	my $logst2 = q{
+	my $logst2 = <<"EOSQL";
 
 	  insert into build_status_log$raw_suffix
 		(sysname, snapshot, branch, log_stage, log_text, stage_duration)
 		values (?, ?, ?, ?, ?, ?)
-
-	    };
+EOSQL
 
 	$sth = $db->prepare($logst2);
 

--- a/cgi-bin/pgstatus.pl
+++ b/cgi-bin/pgstatus.pl
@@ -492,7 +492,6 @@ if ($sqlres)
 		values (?, ?, ?, ?, ?, ?)
 
 	    };
-	}
 
 	$sth = $db->prepare($logst2);
 


### PR DESCRIPTION
cleanfiles.pl previously just nuked everything older than a certain age.
Instead, have it actually query the database to see if the
animal+snapshot has been imported or not.  If the animal+snapshot
doesn't show up after a while, start complaining.

Checking the database only works for files that are 'animal.timestamp'
currently.  Other recognized files (tmp.PID.tgz and tmp.PID.unpacklogs)
are handled as they previously were- ideally these files would end up
changed/renamed to have a similar 'animal.timestamp.something' (or
similar) filename to allow them to also be compared against the
database.

Hidden files are ignored.  A warning is thrown for any other files found
but they're left alone.

In passing, add $raw_tables to BuildFarmWeb.pl.skel since it was
apparently missed.