### PR TITLE
Set auto-submission headers on outgoing emails

### DIFF
--- a/bin/applications_reminder.pl
+++ b/bin/applications_reminder.pl
@@ -57,6 +57,8 @@ my $msg = Mail::Send->new;
 $msg->set('From', $from_addr);
 $msg->to(@$notifyapp);
 $msg->set('Reply-To', @$notifyapp);
+$msg->set('Auto-Submitted', 'auto-generated');
+$msg->set('X-Auto-Response-Suppress', 'all');
 $msg->subject("PGBuildfarm pending applications reminder");
 my $fh = $msg->open("sendmail", "-f $from_addr");
 

--- a/bin/bf-alerts.pl
+++ b/bin/bf-alerts.pl
@@ -266,6 +266,9 @@ foreach my $clearme (@need_cleared)
 	# $sth->finish;
 
 	$msg->to($mailto);
+	$msg->set('Auto-Submitted', 'auto-generated');
+	$msg->set('X-Auto-Response-Suppress', 'all');
+
 	$msg->subject("PGBuildfarm member $animal Branch $branch Alert cleared");
 	my $fh = $msg->open("sendmail", "-f $from_addr");
 	print $fh "\n\n$text\n";
@@ -294,6 +297,8 @@ foreach my $needme (@need_alerts)
 	print "sending alert to $mailto\n";
 
 	$msg->to($mailto);
+	$msg->set('Auto-Submitted', 'auto-generated');
+	$msg->set('X-Auto-Response-Suppress', 'all');
 
 	$msg->subject(
 		"PGBuildfarm member $animal Branch $branch " . "Alert notification");

--- a/cgi-bin/pgstatus.pl
+++ b/cgi-bin/pgstatus.pl
@@ -780,6 +780,8 @@ if (@$mailto or @$bcc_stat)
 
 	$msg->to(@$mailto)    if (@$mailto);
 	$msg->bcc(@$bcc_stat) if (@$bcc_stat);
+	$msg->set('Auto-Submitted', 'auto-generated');
+	$msg->set('X-Auto-Response-Suppress', 'all');
 	$msg->subject(
 		"PGBuildfarm member $animal Branch $branch $stat_type $stage");
 	$msg->set('From', $from_addr);
@@ -833,6 +835,8 @@ if (@$mailto or @$bcc_chg)
 
 	$msg->subject(
 		"PGBuildfarm member $animal Branch $branch Status $stat_type");
+	$msg->set('Auto-Submitted', 'auto-generated');
+	$msg->set('X-Auto-Response-Suppress', 'all');
 	$msg->set('From', $from_addr);
 	my $fh = $msg->open("sendmail", "-f $from_addr");
 	print $fh unindent(<<"EOMAIL");

--- a/cgi-bin/register.pl
+++ b/cgi-bin/register.pl
@@ -128,6 +128,8 @@ $msg->set('From', $from_addr);
 
 $msg->to(@$notifyapp);
 $msg->set('Reply-To', @$notifyapp);
+$msg->set('Auto-Submitted', 'auto-generated');
+$msg->set('X-Auto-Response-Suppress', 'all');
 $msg->subject('New Buildfarm Application');
 my $fh = $msg->open("sendmail", "-f $from_addr");
 print $fh "\n\nName: $dummyname\n",


### PR DESCRIPTION
Set the "Auto-Submitted: auto-generated" header to indicate that the
email is actually auto-generated (which all of the ones generated from
the code currently are), as well as the "X-Auto-Response-Suppress: all"
to prevent auto-replies going back to the noreply addresses (at least
from compliant systems).

The patch itself isn't tested as I don't have the env for it, but the headers
are tested, in particular in relation to making life in pglister simpler (these
are the same headers that www.postgresql.org sets).