### PR TITLE
Make upgrade and addnotes idempotent

### DIFF
--- a/cgi-bin/addnotes.pl
+++ b/cgi-bin/addnotes.pl
@@ -96,6 +96,8 @@ my $set_notes = q{
                    end
     where name = $1
           and status = 'approved'
+	      -- makes request idempotent
+          and sys_notes is distinct from nullif($2,'')
 
 };
 


### PR DESCRIPTION
This allows running the setnotes.pl and update_personality.pl scripts in the client-code repo repeatedly without causing multiple changes / rows on the server-side.

This has the following advantages:
- It fixes a theoretical problem when the client sends the request successfully, but doesn't receive the response due to a network error - and then tries the same thing again, ending up with a duplicate row for the os/compiler version.
- It allows automating the update of os / compiler versions (and notes, too, in case they contain any version information). This can be as simple as a script run via the same cron job as the build script itself - checking for the current os and compiler version and sending those before each run.