### PR TITLE
Don't blocklist GET requests, instead allowlist POST requests

### DIFF
--- a/cgi-bin/pgstatus.pl
+++ b/cgi-bin/pgstatus.pl
@@ -65,7 +65,7 @@ my $query = CGI->new;
 if ($query->request_method ne 'POST')
 {
 	print
-	  "Status: 496 wrong request method\nContent-Type: text/plain\n\n",
+	  "Status: 405 Method Not Allowed\nContent-Type: text/plain\n\n",
 	  "wrong request method\n";
 	exit;
 }

--- a/cgi-bin/pgstatus.pl
+++ b/cgi-bin/pgstatus.pl
@@ -60,9 +60,9 @@ $dsn .= ";port=$dbport" if $dbport;
 
 my $query = CGI->new;
 
-# don't let people play games with GET requests - this should be called via POST
+# don't let people play games with GET (or other) requests - this should be called via POST
 # the URL should only contain the signature
-if ($query->request_method eq 'GET')
+if ($query->request_method ne 'POST')
 {
 	print
 	  "Status: 496 wrong request method\nContent-Type: text/plain\n\n",


### PR DESCRIPTION
There are many more request types than GET and POST, and there is no reason to accept them.

(Not a high priority one, but it just flags as bad to do blocking of a single one when we really don't want the others, so good for some hygiene)